### PR TITLE
[FIX] Use correct shift between start and end in UpdateSize

### DIFF
--- a/cockpit/quantities/update_size.py
+++ b/cockpit/quantities/update_size.py
@@ -10,10 +10,10 @@ class UpdateSize(TwoStepQuantity):
     """str: String under which the parameters are cached for computation.
        Default: ``'params'``.
     """
-    SAVE_SHIFT = 0
-    """int: Difference between iteration at which information is computed versus 
-       iteration under which it is stored. For instance, if set to ``1``, the 
-       information computed at iteration ``n + 1`` is saved under iteration ``n``. 
+    SAVE_SHIFT = 1
+    """int: Difference between iteration at which information is computed versus
+       iteration under which it is stored. For instance, if set to ``1``, the
+       information computed at iteration ``n + 1`` is saved under iteration ``n``.
        Defaults to ``1``.
     """
 


### PR DESCRIPTION
The old value was correctly documented to be 1, but wrongly set to 0.
This lead to the UpdateSize being zero, because parameters from the same
iteration would be used as start/end points in the computation.