### PR TITLE
Add savefig_kwargs and fix savedir parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 
 [![CI](https://github.com/f-dangel/cockpit/actions/workflows/CI.yml/badge.svg)](https://github.com/f-dangel/cockpit/actions/workflows/CI.yml)
 [![Lint](https://github.com/f-dangel/cockpit/actions/workflows/Lint.yml/badge.svg)](https://github.com/f-dangel/cockpit/actions/workflows/Lint.yml)
-[![Doc](https://img.shields.io/readthedocs/cockpit/development.svg?logo=read%20the%20docs&logoColor=white&label=Doc)](https://cockpit.readthedocs.io)
-[![Coverage](https://coveralls.io/repos/github/f-dangel/cockpit/badge.svg?branch=development&t=piyZHm)](https://coveralls.io/github/f-dangel/cockpit?branch=development)
+[![Doc](https://img.shields.io/readthedocs/cockpit/latest.svg?logo=read%20the%20docs&logoColor=white&label=Doc)](https://cockpit.readthedocs.io)
+[![Coverage](https://coveralls.io/repos/github/f-dangel/cockpit/badge.svg?branch=main&t=piyZHm)](https://coveralls.io/github/f-dangel/cockpit?branch=main)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/f-dangel/cockpit/blob/master/LICENSE)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![arXiv](https://img.shields.io/static/v1?logo=arxiv&logoColor=white&label=Preprint&message=2102.06604&color=B31B1B)](https://arxiv.org/abs/2102.06604)
@@ -27,7 +27,7 @@
 ---
 
 ```bash
-pip install 'git+https://github.com/f-dangel/cockpit.git@development'
+pip install 'git+https://github.com/f-dangel/cockpit.git'
 ```
 
 ---
@@ -44,7 +44,7 @@ pip install 'git+https://github.com/f-dangel/cockpit.git@development'
 To install **Cockpit** simply run
 
 ```bash
-pip install 'git+https://github.com/f-dangel/cockpit.git@development'
+pip install 'git+https://github.com/f-dangel/cockpit.git'
 ```
 
 <!-- Documentation -->

--- a/cockpit/plotter.py
+++ b/cockpit/plotter.py
@@ -61,11 +61,13 @@ class CockpitPlotter:
     def plot(
         self,
         source,
-        savedir=None,
         show_plot=True,
-        save_plot=False,
-        savename_append=None,
         block=False,
+        save_plot=False,
+        savedir=None,
+        savename="cockpit",
+        savename_append=None,
+        savefig_kwargs=None,
         show_log_iter=False,
         discard=None,
         plot_title=None,
@@ -77,15 +79,18 @@ class CockpitPlotter:
             source (Cockpit or str): ``Cockpit`` instance, or string
                 containing the path to a .json log produced with ``Cockpit.write``,
                 where information will be fetched from.
-            savedir (str): Directory where to save the plot.
             show_plot (bool, optional): Whether the plot should be shown on
                 screen. Defaults to True.
-            save_plot (bool, optional): Whether the plot should be saved to disk.
-                Defaults to False.
-            savename_append (str, optional): Optional appendix to the savefile
-                name. Defaults to None.
             block (bool, optional): Whether the halt the computation after
                 blocking or not. Defaults to False.
+            save_plot (bool, optional): Whether the plot should be saved to disk.
+                Defaults to False.
+            savedir (str, optional): Directory where to save the plot.
+            savename (str, optional): Filename of the saved plot.
+            savename_append (str, optional): Optional appendix to the savefile
+                name. Defaults to None.
+            savefig_kwards (dict, optional): Additional keyword arguemnts that
+                are passed to `fig.savefig` such as fileformat or dpi.
             show_log_iter (bool, optional): Whether the instruments should use
                 a log scale for the iterations. Defaults to False.
             discard (int, optional): Global step after which information
@@ -165,10 +170,22 @@ class CockpitPlotter:
                 else:
                     raise ValueError("Please specify savedir when plotting a Cockpit.")
 
-            self._save(savedir, savename_append, screen="primary")
+            self._save(
+                savedir,
+                savename,
+                savename_append,
+                savefig_kwargs,
+                screen="primary",
+            )
 
             if self._secondary_screen:
-                self._save(savedir, savename_append, screen="secondary")
+                self._save(
+                    savedir,
+                    savename,
+                    savename_append,
+                    savefig_kwargs,
+                    screen="secondary",
+                )
 
     def _plot_step(self, grid_spec):
         """Plot all instruments having to do with step size in the given gridspec.
@@ -326,7 +343,7 @@ class CockpitPlotter:
         plot_scale = 1.0  # 0.7 works well for the MacBook
         sns.set_style("dark")
         sns.set_context("paper", font_scale=1.0)
-        self.save_format = ".png"  # how the plots should be saved
+        self.save_format = "png"  # how the plots should be saved
         # Colors #
         self.primary_color = (0.29, 0.45, 0.68, 1.0)  # blue #4a73ad
         self.secondary_color = (0.95, 0.50, 0.20, 1.0)  # orange #f28033
@@ -381,7 +398,14 @@ class CockpitPlotter:
         if discard is not None:
             self.tracking_data = self.tracking_data[self.tracking_data.index <= discard]
 
-    def _save(self, logpath, savename_append=None, screen="primary"):
+    def _save(
+        self,
+        savedir,
+        savename,
+        savename_append,
+        savefig_kwargs,
+        screen="primary",
+    ):
         """Save the (internal) figure to file.
 
         Args:
@@ -396,13 +420,15 @@ class CockpitPlotter:
         """
         if savename_append is None:
             savename_append = ""
+        else:
+            savename_append = "__" + savename_append
 
-        file_path = (
-            os.path.splitext(logpath)[0]
-            + f"__{screen}"
-            + savename_append
-            + self.save_format
-        )
+        file_path = os.path.join(savedir, savename + f"__{screen}" + savename_append)
+
+        if savefig_kwargs is not None and "format" in savefig_kwargs:
+            file_path += "." + savefig_kwargs["format"]
+        else:
+            file_path += "." + self.save_format
 
         if screen == "primary":
             fig = self.fig
@@ -413,9 +439,12 @@ class CockpitPlotter:
 
         print(f"[cockpit|plot] Saving figure in {file_path}")
 
-        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+        os.makedirs(savedir, exist_ok=True)
 
-        fig.savefig(file_path)
+        if savefig_kwargs is None:
+            fig.savefig(file_path)
+        else:
+            fig.savefig(file_path, **savefig_kwargs)
 
     def _post_process_plot(self, plot_title):
         """Process the plotting figure, by adding a title, legend, etc."""

--- a/cockpit/plotter.py
+++ b/cockpit/plotter.py
@@ -89,7 +89,7 @@ class CockpitPlotter:
             savename (str, optional): Filename of the saved plot.
             savename_append (str, optional): Optional appendix to the savefile
                 name. Defaults to None.
-            savefig_kwards (dict, optional): Additional keyword arguemnts that
+            savefig_kwargs (dict, optional): Additional keyword arguments that
                 are passed to `fig.savefig` such as fileformat or dpi.
             show_log_iter (bool, optional): Whether the instruments should use
                 a log scale for the iterations. Defaults to False.

--- a/docs/source/examples/01_basic_fmnist.rst
+++ b/docs/source/examples/01_basic_fmnist.rst
@@ -14,9 +14,9 @@ Simply install **Cockpit** via
 
 .. code:: bash
 
-  pip install 'git+https://github.com/f-dangel/cockpit.git@development'
+  pip install 'git+https://github.com/f-dangel/cockpit.git'
 
-and then copy the `example files <https://github.com/f-dangel/cockpit/tree/development/examples>`_
+and then copy the `example files <https://github.com/f-dangel/cockpit/tree/main/examples>`_
 from the repository or from the code block below. 
 
 .. note::

--- a/docs/source/examples/02_advanced_fmnist.rst
+++ b/docs/source/examples/02_advanced_fmnist.rst
@@ -11,7 +11,7 @@ and ways to customize **Cockpit**.
   <../../../examples/_utils_examples.py>` 
   which provides us with the training data, a convolutional network and a logpath.
   You can copy all `example files 
-  <https://github.com/f-dangel/cockpit/tree/development/examples>`_ from our 
+  <https://github.com/f-dangel/cockpit/tree/main/examples>`_ from our 
   repository.
 
 .. literalinclude:: ../../../examples/02_advanced_fmnist.py

--- a/docs/source/examples/03_deepobs.rst
+++ b/docs/source/examples/03_deepobs.rst
@@ -32,7 +32,7 @@ that you can explore with **Cockpit**.
   with the DeepOBS training loop.
 
 Having the two `utility files from our repository 
-<https://github.com/f-dangel/cockpit/tree/development/examples>`_ we can run
+<https://github.com/f-dangel/cockpit/tree/main/examples>`_ we can run
 
 .. code:: bash
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ Cockpit
 
 .. code:: bash
 
-  pip install 'git+https://github.com/f-dangel/cockpit.git@development'
+  pip install 'git+https://github.com/f-dangel/cockpit.git'
 
 ----
 
@@ -29,7 +29,7 @@ To install **Cockpit** simply run
 
 .. code:: bash
 
-  pip install 'git+https://github.com/f-dangel/cockpit.git@development'
+  pip install 'git+https://github.com/f-dangel/cockpit.git'
 
 
 .. toctree::
@@ -69,12 +69,12 @@ To install **Cockpit** simply run
     :target: https://github.com/f-dangel/cockpit/actions/workflows/Lint.yml
     :alt: Lint Status
 
-.. |Doc Status| image:: https://img.shields.io/readthedocs/cockpit/development.svg?logo=read%20the%20docs&logoColor=white&label=Doc
+.. |Doc Status| image:: https://img.shields.io/readthedocs/cockpit/latest.svg?logo=read%20the%20docs&logoColor=white&label=Doc
     :target: https://cockpit.readthedocs.io
     :alt: Doc Status
 
-.. |Coverage| image:: https://coveralls.io/repos/github/f-dangel/cockpit/badge.svg?branch=development&t=piyZHm
-    :target: https://coveralls.io/github/f-dangel/cockpit?branch=development
+.. |Coverage| image:: https://coveralls.io/repos/github/f-dangel/cockpit/badge.svg?branch=main&t=piyZHm
+    :target: https://coveralls.io/github/f-dangel/cockpit?branch=main
     :alt: CI Status
 
 .. |License| image:: https://img.shields.io/badge/License-MIT-green.svg

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ license = MIT
 keywords = deep-learning, machine-learning, debugging
 platforms = any
 classifiers =
-    Development Status :: 4 - Beta
+    Development Status :: 5 - Production/Stable
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python :: 3


### PR DESCRIPTION
Addresses Issues #8 and #10.

- Added a `savename` argument to the `CockpitPlotter.plot()` function, which lets you define the name, and now the `savedir` should really only describe the **directory**. Fixes #8 

- Added optional `savefig_kwargs` argument to the `CockpitPlotter.plot()` function that gets passed to the `matplotlib` function `fig.savefig()` to, e.g., specify DPI value or use a different file format (e.g. PDF). Fixes #10 
