### PR TITLE
[MNT] Rename package into `cockpit-for-pytorch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [1.0.1] - 2021-10-13
 
-From this version on, `cockpit` will be available on PyPI.
+From this version on, `cockpit` will be available as `cockpit-for-pytorch` on
+PyPI.
 
 ### Added
+- Make library `pip`-installable as `cockpit-for-pytorch`
+  [[PR](https://github.com/f-dangel/cockpit/pull/17)]
 - Require BackPACK main release
   [[PR](https://github.com/f-dangel/cockpit/pull/12)]
 - Added a `savename` argument to the `CockpitPlotter.plot()` function, which lets you define the name, and now the `savedir` should really only describe the **directory**. [[PR](https://github.com/f-dangel/cockpit/pull/16), Fixes #8]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 ---
 
 ```bash
-pip install cockpit
+pip install cockpit-for-pytorch
 ```
 
 ---
@@ -44,7 +44,7 @@ pip install cockpit
 To install **Cockpit** simply run
 
 ```bash
-pip install cockpit
+pip install cockpit-for-pytorch
 ```
 
 <details>

--- a/docs/source/examples/01_basic_fmnist.rst
+++ b/docs/source/examples/01_basic_fmnist.rst
@@ -14,7 +14,7 @@ Simply install **Cockpit** via
 
 .. code:: bash
 
-  pip install cockpit
+  pip install cockpit-for-pytorch
 
 and then copy the `example files <https://github.com/f-dangel/cockpit/tree/main/examples>`_
 from the repository or from the code block below. 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ Cockpit
 
 .. code:: bash
 
-  pip install cockpit
+  pip install cockpit-for-pytorch
 
 ----
 
@@ -29,7 +29,7 @@ To install **Cockpit** simply run
 
 .. code:: bash
 
-  pip install cockpit
+  pip install cockpit-for-pytorch
 
 
 .. toctree::

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,10 +10,12 @@ license = MIT
 keywords = deep-learning, machine-learning, debugging
 platforms = any
 classifiers =
-    Development Status :: 5 - Production/Stable
+    Development Status :: 4 - Beta
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
-    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 # Define which packages are required to run
@@ -28,9 +30,12 @@ install_requires =
     backpack-for-pytorch>=1.3.0
 zip_safe = False
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires =
     setuptools_scm
+
+[options.packages.find]
+exclude = test*
 
 [flake8]
 # Configure flake8 linting, minor differences to pytorch.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = cockpit
+name = cockpit-for-pytorch
 url = https://github.com/f-dangel/cockpit
 description = A Practical Debugging Tool for Training Deep Neural Networks.
 long_description = file: README.md, CHANGELOG.md, LICENSE.txt


### PR DESCRIPTION
`cockpit` is already taken on PyPI. Rename the library into `cockpit-for-pytorch`.