### PR TITLE
[FIX] Using Alpha with non-SGD optimizer and other quantities

### DIFF
--- a/cockpit/cockpit.py
+++ b/cockpit/cockpit.py
@@ -2,6 +2,7 @@
 
 import os
 from collections import defaultdict
+from typing import Set
 
 import json_tricks
 from backpack import disable
@@ -129,6 +130,22 @@ class Cockpit:
             hook = self._merge_batch_grad_transform_hooks(hooks)
 
         return hook
+
+    def _get_protected_savefields(self, global_step: int) -> Set[str]:
+        """Return names of protected BackPACK buffers.
+
+        Args:
+            global_step: Current iteration number.
+
+        Returns:
+            List of protected buffers.
+        """
+        protected = set()
+
+        for q in self.quantities:
+            protected.update(q.protected_savefields(global_step))
+
+        return protected
 
     def __call__(self, global_step, *exts, info=None, debug=False):
         """Returns the backpack extensions that should be used in this iteration.

--- a/cockpit/cockpit.py
+++ b/cockpit/cockpit.py
@@ -219,16 +219,6 @@ class Cockpit:
                 except AttributeError:
                     pass
 
-    @staticmethod
-    def _remove_module_io(module):
-        io_fields = ["input0", "output"]
-
-        for field in io_fields:
-            try:
-                delattr(module, field)
-            except AttributeError:
-                pass
-
     def log(
         self,
         global_step,

--- a/cockpit/context.py
+++ b/cockpit/context.py
@@ -104,7 +104,7 @@ class BackwardCTX:
         self.cp = cp
         self.global_step = global_step
 
-        self.protected_savefields = set(e.savefield for e in custom_exts)
+        self.protected_savefields = {e.savefield for e in custom_exts}
         self.protected_savefields.update(cp._get_protected_savefields(global_step))
 
         # choose context
@@ -118,7 +118,7 @@ class BackwardCTX:
         ):
             # TODO Implement all quantities with hooks and specify protected savefields
             # Remove unprotected buffers in this cleanup hook during backpropagation
-            cleanup_hook = CleanupHook(set(["grad_batch"]))
+            cleanup_hook = CleanupHook({"grad_batch"})
             ext_hook = self._combine_hooks(compute_hook, cleanup_hook)
         else:
             ext_hook = compute_hook

--- a/cockpit/context.py
+++ b/cockpit/context.py
@@ -99,7 +99,9 @@ class BackwardCTX:
         self.cp = cp
         self.global_step = global_step
 
-        self.protected_savefields = [e.savefield for e in custom_exts]
+        self.protected_savefields = set(
+            e.savefield for e in custom_exts
+        ) + cp._get_protected_savefields(global_step)
 
         # choose context
         ext = cp._get_extensions(global_step, custom_exts=custom_exts)

--- a/cockpit/quantities/alpha.py
+++ b/cockpit/quantities/alpha.py
@@ -90,7 +90,7 @@ class Alpha(TwoStepQuantity):
 
         return hooks
 
-    def protected_savefields(self, global_step: int) -> Set[str]:
+    def protected_savefields(self, global_step: int) -> Set[str]:  # noqa: D102
         protected = set()
         if self.is_start(global_step) or self.is_end(global_step):
             if not self.__projection_with_backpack(global_step):

--- a/cockpit/quantities/alpha.py
+++ b/cockpit/quantities/alpha.py
@@ -2,6 +2,7 @@
 
 import itertools
 import warnings
+from typing import Set
 
 import numpy as np
 import torch
@@ -88,6 +89,14 @@ class Alpha(TwoStepQuantity):
                 hooks.append(self._project_with_backpack_end(global_step))
 
         return hooks
+
+    def protected_savefields(self, global_step: int) -> Set[str]:
+        protected = set()
+        if self.is_start(global_step) or self.is_end(global_step):
+            if not self.__projection_with_backpack(global_step):
+                protected.update(["grad_batch"])
+
+        return protected
 
     def is_start(self, global_step):
         """Return whether current iteration is start point.

--- a/cockpit/quantities/hooks/cleanup.py
+++ b/cockpit/quantities/hooks/cleanup.py
@@ -1,0 +1,30 @@
+"""Contains hook that deletes BackPACK buffers during backpropagation."""
+
+from typing import Set
+
+from torch import Tensor
+
+from cockpit.quantities.hooks.base import ParameterExtensionHook
+
+
+class CleanupHook(ParameterExtensionHook):
+    """Deletes specified BackPACK buffers during backpropagation."""
+
+    def __init__(self, delete_savefields: Set[str]):
+        """Store savefields to be deleted in the backward pass.
+
+        Args:
+            delete_savefields: Name of buffers to delete.
+        """
+        super().__init__()
+        self._delete_savefields = delete_savefields
+
+    def param_hook(self, param: Tensor):
+        """Delete BackPACK buffers in parameter.
+
+        Args:
+            param: Trainable parameter which hosts BackPACK quantities.
+        """
+        for savefield in self._delete_savefields:
+            if hasattr(param, savefield):
+                delattr(param, savefield)

--- a/cockpit/quantities/quantity.py
+++ b/cockpit/quantities/quantity.py
@@ -1,6 +1,7 @@
 """Base class for a tracked quantity."""
 
 from collections import defaultdict
+from typing import Set
 
 import numpy
 import torch
@@ -73,6 +74,19 @@ class Quantity:
                 iteration.
         """
         return []
+
+    def protected_savefields(self, global_step: int) -> Set[str]:
+        """Return list of protected BackPACK buffers at the current step.
+
+        Protected buffers will not be freed during a backward pass.
+
+        Args:
+            global_step: The current iteration number.
+
+        Returns:
+            Set of protected savefields.
+        """
+        return set()
 
     def track(self, global_step, params, batch_loss):
         """Perform scheduled computations and store result.

--- a/cockpit/quantities/utils_transforms.py
+++ b/cockpit/quantities/utils_transforms.py
@@ -3,7 +3,7 @@
 import string
 import weakref
 
-from torch import einsum
+from torch import Tensor, einsum
 
 from cockpit.quantities.hooks.base import ParameterExtensionHook
 
@@ -67,20 +67,14 @@ class BatchGradTransformsHook(ParameterExtensionHook):
         super().__init__(savefield=savefield)
         self._transforms = transforms
 
-    def param_hook(self, param):
+    def param_hook(self, param: Tensor):
         """Execute all transformations and store results as dictionary in the parameter.
 
-        Delete individual gradients in the parameter.
-
         Args:
-            param (torch.Tensor): Trainable parameter which hosts BackPACK quantities.
+            param: Trainable parameter which hosts BackPACK quantities.
         """
         param.grad_batch._param_weakref = weakref.ref(param)
         # TODO Delete after backward pass with Cockpit
         param.grad_batch_transforms = {
             key: func(param.grad_batch) for key, func in self._transforms.items()
         }
-        # TODO Delete with a separate hook that also knows which savefield should be
-        # kept because it's protected by the user. See
-        # https://github.com/f-dangel/cockpit-paper/issues/197
-        del param.grad_batch

--- a/tests/test_bugs/test_issue5.py
+++ b/tests/test_bugs/test_issue5.py
@@ -1,6 +1,7 @@
 """Reproduces the bug described in https://github.com/f-dangel/cockpit/issues/5."""
 
 from backpack import extend
+from pytest import raises
 from torch import manual_seed, rand
 from torch.nn import Flatten, Linear, MSELoss, Sequential
 from torch.optim import Adam
@@ -43,13 +44,14 @@ def test_BatchGradTransformsHook_deletes_attribute_required_by_Alpha():
     losses = individual_loss_fn(outputs, labels)
 
     # backward pass
-    with cockpit(
-        global_step,
-        info={
-            "batch_size": N,
-            "individual_losses": losses,
-            "loss": loss,
-            "optimizer": opt_not_sgd,
-        },
-    ):
-        loss.backward(create_graph=cockpit.create_graph(global_step))
+    with raises(AttributeError):
+        with cockpit(
+            global_step,
+            info={
+                "batch_size": N,
+                "individual_losses": losses,
+                "loss": loss,
+                "optimizer": opt_not_sgd,
+            },
+        ):
+            loss.backward(create_graph=cockpit.create_graph(global_step))

--- a/tests/test_bugs/test_issue5.py
+++ b/tests/test_bugs/test_issue5.py
@@ -44,14 +44,13 @@ def test_BatchGradTransformsHook_deletes_attribute_required_by_Alpha():
     losses = individual_loss_fn(outputs, labels)
 
     # backward pass
-    with raises(AttributeError):
-        with cockpit(
-            global_step,
-            info={
-                "batch_size": N,
-                "individual_losses": losses,
-                "loss": loss,
-                "optimizer": opt_not_sgd,
-            },
-        ):
-            loss.backward(create_graph=cockpit.create_graph(global_step))
+    with cockpit(
+        global_step,
+        info={
+            "batch_size": N,
+            "individual_losses": losses,
+            "loss": loss,
+            "optimizer": opt_not_sgd,
+        },
+    ):
+        loss.backward(create_graph=cockpit.create_graph(global_step))

--- a/tests/test_bugs/test_issue5.py
+++ b/tests/test_bugs/test_issue5.py
@@ -1,7 +1,6 @@
 """Reproduces the bug described in https://github.com/f-dangel/cockpit/issues/5."""
 
 from backpack import extend
-from pytest import raises
 from torch import manual_seed, rand
 from torch.nn import Flatten, Linear, MSELoss, Sequential
 from torch.optim import Adam

--- a/tests/test_bugs/test_issue5.py
+++ b/tests/test_bugs/test_issue5.py
@@ -1,0 +1,55 @@
+"""Reproduces the bug described in https://github.com/f-dangel/cockpit/issues/5."""
+
+from backpack import extend
+from torch import manual_seed, rand
+from torch.nn import Flatten, Linear, MSELoss, Sequential
+from torch.optim import Adam
+
+from cockpit import Cockpit
+from cockpit.quantities import Alpha, GradHist1d
+from cockpit.utils.schedules import linear
+
+
+def test_BatchGradTransformsHook_deletes_attribute_required_by_Alpha():
+    """If the optimizer is not SGD, ``Alpha`` needs access to ``.grad_batch``.
+
+    But if an extension that uses ``BatchGradTransformsHook`` is used at the same time,
+    it will delete the ``grad_batch`` attribute during the backward pass. Consequently,
+    ``Alpha`` cannot access the attribute anymore. This leads to the error.
+    """
+    manual_seed(0)
+
+    N, D_in, D_out = 2, 3, 1
+    model = extend(Sequential(Flatten(), Linear(D_in, D_out)))
+
+    opt_not_sgd = Adam(model.parameters(), lr=1e-3)
+    loss_fn = extend(MSELoss(reduction="mean"))
+    individual_loss_fn = MSELoss(reduction="none")
+
+    on_first = linear(1)
+    alpha = Alpha(on_first)
+    uses_BatchGradTransformsHook = GradHist1d(on_first)
+
+    cockpit = Cockpit(
+        model.parameters(), quantities=[alpha, uses_BatchGradTransformsHook]
+    )
+
+    global_step = 0
+    inputs, labels = rand(N, D_in), rand(N, D_out)
+
+    # forward pass
+    outputs = model(inputs)
+    loss = loss_fn(outputs, labels)
+    losses = individual_loss_fn(outputs, labels)
+
+    # backward pass
+    with cockpit(
+        global_step,
+        info={
+            "batch_size": N,
+            "individual_losses": losses,
+            "loss": loss,
+            "optimizer": opt_not_sgd,
+        },
+    ):
+        loss.backward(create_graph=cockpit.create_graph(global_step))


### PR DESCRIPTION
Protects the `'batch_grad'` field in the case where non-SGD is used together with 
other quantities that free `'batch_grad'` for memory performance.

Fixes #5.

@fsschneider: Can you take a look, then squash-merge?